### PR TITLE
postgres-backupにbucket内の最新のファイルからrestoreするパターンを追加

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,3 +181,17 @@ jobs:
           --push \
           -t "${IMAGE_NAME}" \
           .          
+
+  postgres-backup:
+    name: Postgres Backup
+    if: github.event_name == 'push' && contains(github.ref, 'gh-postgres-backup-v9.6')
+    runs-on: ubuntu-18.04
+    env:
+      IMAGE_NAME: ghcr.io/supinf/postgres-backup:9.6
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build & Push
+      run: |
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+        docker build -t "${IMAGE_NAME}" cli-tools/postgres-backup/versions/9.6/
+        docker push "${IMAGE_NAME}"

--- a/cli-tools/postgres-backup/versions/9.6/Dockerfile
+++ b/cli-tools/postgres-backup/versions/9.6/Dockerfile
@@ -1,0 +1,33 @@
+# postgres-backup
+# docker run --rm -it -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION=ap-northeast-1 -e POSTGRES_HOST=192.168.x.x -e S3_BUCKET=my-bucket ghcr.io/supinf/postgres-backup:9.6
+
+FROM alpine:3.18
+
+ENV SCHEDULE= \
+    POSTGRES_DATABASE= \
+    POSTGRES_HOST= \
+    POSTGRES_PORT=5432 \
+    POSTGRES_USER=postgres \
+    POSTGRES_PASSWORD= \
+    POSTGRES_EXTRA_OPTS= \
+    AWS_DEFAULT_REGION=us-west-1 \
+    S3_BUCKET= \
+    S3_PREFIX= \
+    SERVER_SIDE_ENCRYPTION=true \
+    KMS_KEY_ID= \
+    RESTORE_AFTER= \
+    RESTORE_FROM= \
+    RESTORE_FROM_LATEST_FILE_IN=
+
+RUN apk --no-cache add postgresql curl aws-cli
+
+RUN curl -L https://github.com/odise/go-cron/releases/download/v0.0.7/go-cron-linux.gz \
+       | zcat > /usr/local/bin/go-cron \
+    && chmod +x /usr/local/bin/go-cron
+
+ADD entrypoint.sh /
+ADD restore.sh /
+ADD backup.sh /
+ADD restore_from_latest_file_in.sh /
+RUN chmod +x /entrypoint.sh /restore.sh /backup.sh /restore_from_latest_file_in.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/cli-tools/postgres-backup/versions/9.6/backup.sh
+++ b/cli-tools/postgres-backup/versions/9.6/backup.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+echo "Creating dump of ${POSTGRES_DATABASE} @ ${POSTGRES_HOST}:${POSTGRES_PORT}"
+
+export PGPASSWORD=$POSTGRES_PASSWORD
+shellcheck disable=SC2086
+pg_dump -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" \
+  $POSTGRES_EXTRA_OPTS "${POSTGRES_DATABASE}" | gzip > dump.sql.gz
+
+echo "Uploading the dump to ${S3_BUCKET}"
+
+now=$(date +"%Y-%m-%dT%H:%M:%SZ")
+key="s3://${S3_BUCKET}/${S3_PREFIX}${POSTGRES_DATABASE}_${now}.sql.gz"
+
+echo "Uploading to ${key}"
+
+if [ "x${AWS_ACCESS_KEY_ID}" = "x" ]; then
+  credentials=$( curl -s "169.254.170.2${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}" )
+  if [ "x${credentials}" != "x" ]; then
+    AWS_ACCESS_KEY_ID=$( echo "${credentials}" | jq -r '.AccessKeyId' )
+    export AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY=$( echo "${credentials}" | jq -r '.SecretAccessKey' )
+    export AWS_SECRET_ACCESS_KEY
+    AWS_SESSION_TOKEN=$( echo "${credentials}" | jq -r '.Token' )
+    export AWS_SESSION_TOKEN
+  fi
+fi
+
+if [ "${SERVER_SIDE_ENCRYPTION}" = "true" ]; then
+  if [ "x${KMS_KEY_ID}" = "x" ]; then
+    aws s3 cp --sse AES256 dump.sql.gz "${key}" || exit 2
+  else
+    aws s3 cp --sse aws:kms --sse-kms-key-id "${KMS_KEY_ID}" dump.sql.gz "${key}" || exit 2
+  fi
+else
+  aws s3 cp dump.sql.gz "${key}" || exit 2
+fi
+
+echo "Uploaded successfully"

--- a/cli-tools/postgres-backup/versions/9.6/entrypoint.sh
+++ b/cli-tools/postgres-backup/versions/9.6/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+if [ "x${POSTGRES_DATABASE}" = "x" ]; then
+  echo "You need to specify POSTGRES_DATABASE as an environment variable."
+  exit 1
+fi
+if [ "x${POSTGRES_HOST}" = "x" ]; then
+  echo "You need to specify POSTGRES_HOST as an environment variable."
+  exit 1
+fi
+if [ "x${S3_BUCKET}" = "x" ]; then
+  echo "You need to specify S3_BUCKET as an environment variable."
+  exit 1
+fi
+
+if [ "x${RESTORE_FROM}" != "x" ]; then
+  if [ "x${RESTORE_AFTER}" != "x" ]; then
+    sleep "${RESTORE_AFTER}"
+  fi
+  sh restore.sh
+else
+  if [ "x${RESTORE_FROM_LATEST_FILE_IN}" != "x" ]; then
+    if [ "x${RESTORE_AFTER}" != "x" ]; then
+      sleep "${RESTORE_AFTER}"
+    fi
+    sh restore_from_latest_file_in.sh
+  fi
+fi
+
+if [ "x${SCHEDULE}" = "x" ]; then
+  sh backup.sh
+else
+  exec go-cron -s "${SCHEDULE}" -p 10080 -- /bin/sh backup.sh
+fi

--- a/cli-tools/postgres-backup/versions/9.6/restore.sh
+++ b/cli-tools/postgres-backup/versions/9.6/restore.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+echo "Restore to ${POSTGRES_DATABASE} @ ${POSTGRES_HOST}:${POSTGRES_PORT}"
+
+echo "downloading file /${S3_BUCKET}/${RESTORE_FROM}"
+
+aws s3 cp "s3://${S3_BUCKET}/${RESTORE_FROM}" dump.sql.gz || exit 2
+sleep 1
+gzip -d dump.sql.gz
+
+export PGPASSWORD=$POSTGRES_PASSWORD
+psql -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" \
+    "${POSTGRES_DATABASE}" < dump.sql

--- a/cli-tools/postgres-backup/versions/9.6/restore_from_latest_file_in.sh
+++ b/cli-tools/postgres-backup/versions/9.6/restore_from_latest_file_in.sh
@@ -2,6 +2,8 @@
 set -e
 
 echo "get latest file from ${S3_BUCKET}/${RESTORE_FROM_LATEST_FILE_IN}"
+# the number of objects in the prefix need to be less than 1000. 
+# https://docs.aws.amazon.com/cli/latest/reference/s3api/list-objects.html
 LATEST_FILE_KEY=$(aws s3api list-objects --bucket ${S3_BUCKET} --prefix ${RESTORE_FROM_LATEST_FILE_IN} --query "max_by(Contents, &LastModified).Key" --output text)
 
 echo "downloading latest file ${LATEST_FILE_KEY}"

--- a/cli-tools/postgres-backup/versions/9.6/restore_from_latest_file_in.sh
+++ b/cli-tools/postgres-backup/versions/9.6/restore_from_latest_file_in.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+echo "get latest file from ${S3_BUCKET}/${RESTORE_FROM_LATEST_FILE_IN}"
+LATEST_FILE_KEY=$(aws s3api list-objects --bucket ${S3_BUCKET} --prefix ${RESTORE_FROM_LATEST_FILE_IN} --query "max_by(Contents, &LastModified).Key" --output text)
+
+echo "downloading latest file ${LATEST_FILE_KEY}"
+
+aws s3 cp "s3://${S3_BUCKET}/${LATEST_FILE_KEY}" dump.sql.gz || exit 2
+sleep 1
+gzip -d dump.sql.gz
+
+echo "Restore to ${POSTGRES_DATABASE} @ ${POSTGRES_HOST}:${POSTGRES_PORT}"
+export PGPASSWORD=$POSTGRES_PASSWORD
+psql -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" \
+    "${POSTGRES_DATABASE}" < dump.sql


### PR DESCRIPTION
`9.5`からの変更点
- `alpine 3.18` に更新。
  - `alpine 3.18` で aws cli v2 が `apk add aws-cli` で入るようになっていたので、そちらを使うようにする。
- `RESTORE_FROM_LATEST_FILE_IN` という環境変数を追加。
  - それが指定されている場合 `restore_from_latest_file_in.sh` を実行するようにする。
  - 基本的な動作はこれまでの `restore.sh` と同じだが、対象のファイル名を環境変数で受け取るのではなくて、対象のbucket のprefixを受け取って、その中で一番更新日時が新しいファイル取得する挙動にする。以下のクエリーで最新のファイルのkeyを取得している。
    - `aws s3api list-objects --bucket ${S3_BUCKET} --prefix ${RESTORE_FROM_LATEST_FILE_IN} --query "max_by(Contents, &LastModified).Key" --output text`
    - ただし、 s3api の仕様上、1000ファイルが上限となっていて、backupするbucketのライフサイクルなどで1000以下になるように運用する必要がある。
- DockerHub でのリリースから、 ghcr でのリリースに変更。

後続作業
- `gh-postgres-backup-v9.6`のTagを作成し、ghcr に push 予定。