### PR TITLE
update: base image for swagger codegen 2.4

### DIFF
--- a/java/swagger-codegen/versions/2.4/Dockerfile
+++ b/java/swagger-codegen/versions/2.4/Dockerfile
@@ -6,7 +6,7 @@
 # docker run --rm -it -v `pwd`:/src supinf/swagger-codegen:2.4 \
 #    generate -i /src/swagger.yaml -o /src/generated -l javascript
 
-FROM maven:3-jdk-8-alpine
+FROM openjdk:8u131-jre-alpine
 
 ENV SWAGGER_CODEGEN_VERSION=2.4.7
 

--- a/java/swagger-codegen/versions/2.4/Dockerfile
+++ b/java/swagger-codegen/versions/2.4/Dockerfile
@@ -6,13 +6,13 @@
 # docker run --rm -it -v `pwd`:/src supinf/swagger-codegen:2.4 \
 #    generate -i /src/swagger.yaml -o /src/generated -l javascript
 
-FROM openjdk:8u131-jre-alpine
+FROM maven:3-jdk-8-alpine
 
 ENV SWAGGER_CODEGEN_VERSION=2.4.7
 
 ADD swagger-codegen /usr/bin/
 RUN chmod +x /usr/bin/swagger-codegen \
-    && apk --no-cache add bash
+    && apk upgrade && apk --no-cache add bash
 
 RUN apk --no-cache add --virtual build-deps curl \
     && repo="https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/${SWAGGER_CODEGEN_VERSION}" \


### PR DESCRIPTION
# 修正内容
- swagger-codegen-cli:2.4のbase imageを2.3と同じにする

# 修正理由
- 下記のcurlで`Segmentation fault (core dumped)`というエラーが発生する様になったため
```
curl --location --silent --show-error --out /swagger-codegen-cli.jar \
        ${repo}/swagger-codegen-cli-${SWAGGER_CODEGEN_VERSION}.jar
```